### PR TITLE
Fix CallNeedsPermissionDetector

### DIFF
--- a/lint/src/test/java/permissions/dispatcher/CallNeedsPermissionDetectorTest.java
+++ b/lint/src/test/java/permissions/dispatcher/CallNeedsPermissionDetectorTest.java
@@ -70,7 +70,11 @@ public final class CallNeedsPermissionDetectorTest {
 
         @Language("JAVA") String baz = ""
                 + "package com.example;\n"
+                + "import permissions.dispatcher.NeedsPermission;\n"
                 + "public class Baz {\n"
+                + "@NeedsPermission(\"Test\")\n"
+                + "public void fooBar() {\n"
+                + "}\n"
                 + "public void noFooBar() {\n"
                 + "}\n"
                 + "}";

--- a/lint/src/test/java/permissions/dispatcher/CallNeedsPermissionDetectorTest.java
+++ b/lint/src/test/java/permissions/dispatcher/CallNeedsPermissionDetectorTest.java
@@ -3,16 +3,17 @@ package permissions.dispatcher;
 import org.intellij.lang.annotations.Language;
 import org.junit.Test;
 
-import java.util.Collections;
-
 import static com.android.tools.lint.checks.infrastructure.TestFiles.java;
 import static com.android.tools.lint.checks.infrastructure.TestLintTask.lint;
+import static permissions.dispatcher.Utils.SOURCE_PATH;
+import static permissions.dispatcher.Utils.getOnNeedsPermission;
 
 public final class CallNeedsPermissionDetectorTest {
 
     @Test
     public void callNeedsPermissionMethod() throws Exception {
-        CallNeedsPermissionDetector.methods = Collections.singletonList("fooBar");
+
+        @Language("JAVA") String onNeeds = getOnNeedsPermission();
 
         @Language("JAVA") String foo = ""
                 + "package com.example;\n"
@@ -25,7 +26,9 @@ public final class CallNeedsPermissionDetectorTest {
 
         @Language("JAVA") String baz = ""
                 + "package com.example;\n"
+                + "import permissions.dispatcher.NeedsPermission;\n"
                 + "public class Baz {\n"
+                + "@NeedsPermission(\"Test\")\n"
                 + "public void fooBar() {\n"
                 + "}\n"
                 + "}";
@@ -41,6 +44,7 @@ public final class CallNeedsPermissionDetectorTest {
 
         lint()
                 .files(
+                        java(SOURCE_PATH + "NeedsPermission.java", onNeeds),
                         java("src/com/example/Foo.java", foo),
                         java("src/com/example/Baz.java", baz))
                 .issues(CallNeedsPermissionDetector.ISSUE)
@@ -52,7 +56,8 @@ public final class CallNeedsPermissionDetectorTest {
 
     @Test
     public void callNeedsPermissionMethodNoError() throws Exception {
-        CallNeedsPermissionDetector.methods = Collections.singletonList("fooBar");
+
+        @Language("JAVA") String onNeeds = getOnNeedsPermission();
 
         @Language("JAVA") String foo = ""
                 + "package com.example;\n"
@@ -72,6 +77,7 @@ public final class CallNeedsPermissionDetectorTest {
 
         lint()
                 .files(
+                        java(SOURCE_PATH + "NeedsPermission.java", onNeeds),
                         java("src/com/example/Foo.java", foo),
                         java("src/com/example/Baz.java", baz))
                 .issues(CallNeedsPermissionDetector.ISSUE)


### PR DESCRIPTION
## Issue

- None

## Overview

- I found that `CallNeedsPermissionDetector` lint check hasn't been working since around 2.2.0... 😢
  - The reason is basically somehow we missed [these logics](https://github.com/permissions-dispatcher/PermissionsDispatcher/blob/2.2.0/lint/src/main/java/permissions/dispatcher/CallNeedsPermissionDetector.java#L97-L109) which actually detect illegal method call.
  - Actually unit test cases were weird and that's why we couldn't notice that.
- So I fixed both the logic itself and test case.