### PR TITLE
Fix the way of detecting @NeedsPermission annotated method calling

### DIFF
--- a/lint/src/main/java/permissions/dispatcher/CallNeedsPermissionDetector.java
+++ b/lint/src/main/java/permissions/dispatcher/CallNeedsPermissionDetector.java
@@ -62,7 +62,7 @@ public final class CallNeedsPermissionDetector extends Detector implements Detec
             if (isGeneratedFiles(context)) {
                 return true;
             }
-            if (annotatedMethods.contains(node.getMethodName())) {
+            if (node.getReceiver() == null && annotatedMethods.contains(node.getMethodName())) {
                 context.report(ISSUE, node, context.getLocation(node), "Trying to access permission-protected method directly");
             }
             return true;

--- a/lint/src/test/java/permissions/dispatcher/CallNeedsPermissionDetectorTest.java
+++ b/lint/src/test/java/permissions/dispatcher/CallNeedsPermissionDetectorTest.java
@@ -17,36 +17,29 @@ public final class CallNeedsPermissionDetectorTest {
 
         @Language("JAVA") String foo = ""
                 + "package com.example;\n"
-                + "public class Foo {\n"
-                + "public void someMethod() {"
-                + "Baz baz = new Baz();\n"
-                + "baz.fooBar();  "
-                + "}\n"
-                + "}";
-
-        @Language("JAVA") String baz = ""
-                + "package com.example;\n"
                 + "import permissions.dispatcher.NeedsPermission;\n"
-                + "public class Baz {\n"
+                + "public class Foo {\n"
                 + "@NeedsPermission(\"Test\")\n"
                 + "public void fooBar() {\n"
+                + "}\n"
+                + "public void hoge() {\n"
+                + "fooBar();\n"
                 + "}\n"
                 + "}";
 
         String expectedText = ""
-                + "src/com/example/Foo.java:4: Error: Trying to access permission-protected method directly "
+                + "src/com/example/Foo.java:8: Error: Trying to access permission-protected method directly "
                 + "["
                 + CallNeedsPermissionDetector.ISSUE.getId()
                 + "]\n"
-                + "baz.fooBar();  }\n"
-                + "~~~~~~~~~~~~\n"
+                + "fooBar();\n"
+                + "~~~~~~~~\n"
                 + "1 errors, 0 warnings\n";
 
         lint()
                 .files(
                         java(SOURCE_PATH + "NeedsPermission.java", onNeeds),
-                        java("src/com/example/Foo.java", foo),
-                        java("src/com/example/Baz.java", baz))
+                        java("src/com/example/Foo.java", foo))
                 .issues(CallNeedsPermissionDetector.ISSUE)
                 .run()
                 .expect(expectedText)


### PR DESCRIPTION
## Issue

addresses https://github.com/permissions-dispatcher/PermissionsDispatcher/issues/377

## Overview

- Fix to detect @NeedsPermission annotated method calling when the receiver of the method is null.
  - Otherwise if activity/fragment calls the same method name as NeedsPermission annotated one lint flags it incorrectly.