### PR TITLE
Add temporal extension method which converts java.lang.String to kotlin.String

### DIFF
--- a/processor/src/main/kotlin/permissions/dispatcher/processor/impl/kotlin/KotlinBaseProcessorUnit.kt
+++ b/processor/src/main/kotlin/permissions/dispatcher/processor/impl/kotlin/KotlinBaseProcessorUnit.kt
@@ -5,18 +5,7 @@ import permissions.dispatcher.NeedsPermission
 import permissions.dispatcher.processor.KtProcessorUnit
 import permissions.dispatcher.processor.RequestCodeProvider
 import permissions.dispatcher.processor.RuntimePermissionsElement
-import permissions.dispatcher.processor.util.FILE_COMMENT
-import permissions.dispatcher.processor.util.addFunctions
-import permissions.dispatcher.processor.util.addProperties
-import permissions.dispatcher.processor.util.addTypes
-import permissions.dispatcher.processor.util.pendingRequestFieldName
-import permissions.dispatcher.processor.util.permissionFieldName
-import permissions.dispatcher.processor.util.permissionRequestTypeName
-import permissions.dispatcher.processor.util.permissionValue
-import permissions.dispatcher.processor.util.requestCodeFieldName
-import permissions.dispatcher.processor.util.simpleString
-import permissions.dispatcher.processor.util.varargsKtParametersCodeBlock
-import permissions.dispatcher.processor.util.WithPermissionCheckMethodName
+import permissions.dispatcher.processor.util.*
 import java.util.*
 import javax.lang.model.element.ExecutableElement
 
@@ -110,7 +99,7 @@ abstract class KotlinBaseProcessorUnit : KtProcessorUnit {
 
         // If the method has parameters, add those as well
         method.parameters.forEach {
-            builder.addParameter(it.simpleString(), it.asType().asTypeName())
+            builder.addParameter(it.simpleString(), it.asType().asTypeName().checkStringType())
         }
 
         // Delegate method body generation to implementing classes
@@ -367,7 +356,7 @@ abstract class KotlinBaseProcessorUnit : KtProcessorUnit {
 
         needsMethod.parameters.forEach {
             builder.addProperty(
-                    PropertySpec.builder(it.simpleString(), it.asType().asTypeName(), KModifier.PRIVATE)
+                    PropertySpec.builder(it.simpleString(), it.asType().asTypeName().checkStringType(), KModifier.PRIVATE)
                             .initializer(CodeBlock.of(it.simpleString()))
                             .build()
             )
@@ -377,7 +366,7 @@ abstract class KotlinBaseProcessorUnit : KtProcessorUnit {
         val targetParam = "target"
         val constructorSpec = FunSpec.constructorBuilder().addParameter(targetParam, rpe.ktTypeName)
         needsMethod.parameters.forEach {
-            constructorSpec.addParameter(it.simpleString(), it.asType().asTypeName(), KModifier.PRIVATE)
+            constructorSpec.addParameter(it.simpleString(), it.asType().asTypeName().checkStringType(), KModifier.PRIVATE)
         }
         builder.primaryConstructor(constructorSpec.build())
 

--- a/processor/src/main/kotlin/permissions/dispatcher/processor/util/Extensions.kt
+++ b/processor/src/main/kotlin/permissions/dispatcher/processor/util/Extensions.kt
@@ -1,9 +1,6 @@
 package permissions.dispatcher.processor.util
 
-import com.squareup.kotlinpoet.FunSpec
-import com.squareup.kotlinpoet.KotlinFile
-import com.squareup.kotlinpoet.PropertySpec
-import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.*
 import permissions.dispatcher.NeedsPermission
 import permissions.dispatcher.OnNeverAskAgain
 import permissions.dispatcher.OnPermissionDenied
@@ -97,3 +94,10 @@ fun KotlinFile.Builder.addTypes(types: List<TypeSpec>): KotlinFile.Builder {
     types.forEach { addType(it) }
     return this
 }
+
+/**
+ * To avoid KotlinPoet bug that returns java.lang.String when type name is kotlin.String.
+ * This method should be removed after addressing on KotlinPoet side.
+ */
+fun TypeName.checkStringType() =
+        if (this.toString() == "java.lang.String") ClassName("kotlin", "String") else this


### PR DESCRIPTION
## Issue

- https://github.com/permissions-dispatcher/PermissionsDispatcher/issues/376
  - kotlin.String converts to java.lang.String

## Overview

- Add temporal extension method which converts java.lang.String to kotlin.String.
  - This is arguably a bug of KotlinPoet so we're going to file a bug report!