### PR TITLE
Fix incorrect link to migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ repositories {
 
 - If you include [Jitpack.io](https://jitpack.io/) dependencies in your project, it is important to review the order of the repositories available to your app module
   - Because of the library's artifact ID, Jitpack might be tempted to resolve the dependency on its own, which could lead to an error during Gradle's configuration time
-- If you're going to bump up the major version number we recommend to refer to [migration guide](https://github.com/hotchemi/PermissionsDispatcher/blob/master/doc/kotlin_support.md) 
+- If you're going to bump up the major version number we recommend to refer to [migration guide](https://github.com/hotchemi/PermissionsDispatcher/blob/master/doc/migration_guide.md) 
 
 ## Licence
 


### PR DESCRIPTION
migration guide link was pointing to Kotlin support info.