### PR TITLE
Honor nullable params in Kotlin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-26.0.1
+    - build-tools-26.0.2
     - android-26
     - extra-google-google_play_services
     - extra-android-m2repository

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ WEBSITE                 = https://github.com/hotchemi/PermissionsDispatcher
 LICENCES                = ['Apache-2.0']
 
 # Plugin versions
-GRADLE_PLUGIN_VERSION   = 3.0.0-rc1
+GRADLE_PLUGIN_VERSION   = 3.0.0
 KOTLIN_VERSION          = 1.1.51
 BINTRAY_PLUGIN_VERSION  = 0.5.0
 CONFIG_PLUGIN_VERSION   = 2.2.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ WEBSITE                 = https://github.com/hotchemi/PermissionsDispatcher
 LICENCES                = ['Apache-2.0']
 
 # Plugin versions
-GRADLE_PLUGIN_VERSION   = 3.0.0-beta6
+GRADLE_PLUGIN_VERSION   = 3.0.0-rc1
 KOTLIN_VERSION          = 1.1.51
 BINTRAY_PLUGIN_VERSION  = 0.5.0
 CONFIG_PLUGIN_VERSION   = 2.2.2
@@ -30,7 +30,7 @@ ROBOLECTRIC_VERSION     = 3.3.2
 
 # Android configuration
 COMPILE_SDK_VERSION     = android-26
-BUILD_TOOLS_VERSION     = 26.0.1
+BUILD_TOOLS_VERSION     = 26.0.2
 TARGET_SDK_VERSION      = 25
 MIN_SDK_VERSION         = 14
 

--- a/processor/src/main/kotlin/permissions/dispatcher/processor/PermissionsProcessor.kt
+++ b/processor/src/main/kotlin/permissions/dispatcher/processor/PermissionsProcessor.kt
@@ -85,13 +85,13 @@ class PermissionsProcessor : AbstractProcessor() {
             kaptGeneratedDir.parentFile.mkdirs()
         }
 
-        val processorUnit = findAndValidateProcessorUnit(kotlinProcessorUnits(), element)
+        val processorUnit = findAndValidateProcessorUnit(kotlinProcessorUnits(messager), element)
         val kotlinFile = processorUnit.createFile(rpe, requestCodeProvider)
         kotlinFile.writeTo(kaptGeneratedDir)
     }
 
     private fun processJava(element: Element, rpe: RuntimePermissionsElement, requestCodeProvider: RequestCodeProvider) {
-        val processorUnit = findAndValidateProcessorUnit(javaProcessorUnits(), element)
+        val processorUnit = findAndValidateProcessorUnit(javaProcessorUnits(messager), element)
         val javaFile = processorUnit.createFile(rpe, requestCodeProvider)
         javaFile.writeTo(filer)
     }

--- a/processor/src/main/kotlin/permissions/dispatcher/processor/impl/ProcessorUnits.kt
+++ b/processor/src/main/kotlin/permissions/dispatcher/processor/impl/ProcessorUnits.kt
@@ -6,13 +6,14 @@ import permissions.dispatcher.processor.impl.java.JavaSupportFragmentProcessorUn
 import permissions.dispatcher.processor.impl.kotlin.KotlinActivityProcessorUnit
 import permissions.dispatcher.processor.impl.kotlin.KotlinNativeFragmentProcessorUnit
 import permissions.dispatcher.processor.impl.kotlin.KotlinSupportFragmentProcessorUnit
+import javax.annotation.processing.Messager
 
-fun javaProcessorUnits() = listOf(
-        JavaActivityProcessorUnit(),
-        JavaSupportFragmentProcessorUnit(),
-        JavaNativeFragmentProcessorUnit())
+fun javaProcessorUnits(messager: Messager) = listOf(
+        JavaActivityProcessorUnit(messager),
+        JavaSupportFragmentProcessorUnit(messager),
+        JavaNativeFragmentProcessorUnit(messager))
 
-fun kotlinProcessorUnits() = listOf(
-        KotlinActivityProcessorUnit(),
-        KotlinSupportFragmentProcessorUnit(),
-        KotlinNativeFragmentProcessorUnit())
+fun kotlinProcessorUnits(messager: Messager) = listOf(
+        KotlinActivityProcessorUnit(messager),
+        KotlinSupportFragmentProcessorUnit(messager),
+        KotlinNativeFragmentProcessorUnit(messager))

--- a/processor/src/main/kotlin/permissions/dispatcher/processor/impl/java/JavaActivityProcessorUnit.kt
+++ b/processor/src/main/kotlin/permissions/dispatcher/processor/impl/java/JavaActivityProcessorUnit.kt
@@ -3,12 +3,13 @@ package permissions.dispatcher.processor.impl.java
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.MethodSpec
 import permissions.dispatcher.processor.util.*
+import javax.annotation.processing.Messager
 import javax.lang.model.type.TypeMirror
 
 /**
  * ProcessorUnit implementation for Activity classes.
  */
-class JavaActivityProcessorUnit : JavaBaseProcessorUnit() {
+class JavaActivityProcessorUnit(messager: Messager) : JavaBaseProcessorUnit(messager) {
 
     private val ACTIVITY_COMPAT = ClassName.get("android.support.v4.app", "ActivityCompat")
 

--- a/processor/src/main/kotlin/permissions/dispatcher/processor/impl/java/JavaBaseProcessorUnit.kt
+++ b/processor/src/main/kotlin/permissions/dispatcher/processor/impl/java/JavaBaseProcessorUnit.kt
@@ -7,6 +7,7 @@ import permissions.dispatcher.processor.RequestCodeProvider
 import permissions.dispatcher.processor.RuntimePermissionsElement
 import permissions.dispatcher.processor.util.*
 import java.util.*
+import javax.annotation.processing.Messager
 import javax.lang.model.element.ExecutableElement
 import javax.lang.model.element.Modifier
 
@@ -15,7 +16,7 @@ import javax.lang.model.element.Modifier
  * <p>
  * This generates the parts of code independent from specific permission method signatures for different target objects.
  */
-abstract class JavaBaseProcessorUnit : JavaProcessorUnit {
+abstract class JavaBaseProcessorUnit(val messager: Messager) : JavaProcessorUnit {
 
     protected val PERMISSION_UTILS: ClassName = ClassName.get("permissions.dispatcher", "PermissionUtils")
     private val BUILD = ClassName.get("android.os", "Build")

--- a/processor/src/main/kotlin/permissions/dispatcher/processor/impl/java/JavaNativeFragmentProcessorUnit.kt
+++ b/processor/src/main/kotlin/permissions/dispatcher/processor/impl/java/JavaNativeFragmentProcessorUnit.kt
@@ -2,9 +2,10 @@ package permissions.dispatcher.processor.impl.java
 
 import com.squareup.javapoet.MethodSpec
 import permissions.dispatcher.processor.util.*
+import javax.annotation.processing.Messager
 import javax.lang.model.type.TypeMirror
 
-class JavaNativeFragmentProcessorUnit : JavaBaseProcessorUnit() {
+class JavaNativeFragmentProcessorUnit(messager: Messager) : JavaBaseProcessorUnit(messager) {
 
     override fun getTargetType(): TypeMirror {
         return typeMirrorOf("android.app.Fragment")

--- a/processor/src/main/kotlin/permissions/dispatcher/processor/impl/java/JavaSupportFragmentProcessorUnit.kt
+++ b/processor/src/main/kotlin/permissions/dispatcher/processor/impl/java/JavaSupportFragmentProcessorUnit.kt
@@ -2,12 +2,13 @@ package permissions.dispatcher.processor.impl.java
 
 import com.squareup.javapoet.MethodSpec
 import permissions.dispatcher.processor.util.*
+import javax.annotation.processing.Messager
 import javax.lang.model.type.TypeMirror
 
 /**
  * ProcessorUnit implementation for Fragments defined in the support-v4 library.
  */
-class JavaSupportFragmentProcessorUnit : JavaBaseProcessorUnit() {
+class JavaSupportFragmentProcessorUnit(messager: Messager) : JavaBaseProcessorUnit(messager) {
 
     override fun getTargetType(): TypeMirror {
         return typeMirrorOf("android.support.v4.app.Fragment")

--- a/processor/src/main/kotlin/permissions/dispatcher/processor/impl/kotlin/KotlinActivityProcessorUnit.kt
+++ b/processor/src/main/kotlin/permissions/dispatcher/processor/impl/kotlin/KotlinActivityProcessorUnit.kt
@@ -3,12 +3,13 @@ package permissions.dispatcher.processor.impl.kotlin
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import permissions.dispatcher.processor.util.*
+import javax.annotation.processing.Messager
 import javax.lang.model.type.TypeMirror
 
 /**
  * [permissions.dispatcher.processor.KtProcessorUnit] implementation for Activity classes.
  */
-class KotlinActivityProcessorUnit : KotlinBaseProcessorUnit() {
+class KotlinActivityProcessorUnit(messager: Messager) : KotlinBaseProcessorUnit(messager) {
 
     private val ACTIVITY_COMPAT = ClassName("android.support.v4.app", "ActivityCompat")
 

--- a/processor/src/main/kotlin/permissions/dispatcher/processor/impl/kotlin/KotlinBaseProcessorUnit.kt
+++ b/processor/src/main/kotlin/permissions/dispatcher/processor/impl/kotlin/KotlinBaseProcessorUnit.kt
@@ -7,6 +7,7 @@ import permissions.dispatcher.processor.RequestCodeProvider
 import permissions.dispatcher.processor.RuntimePermissionsElement
 import permissions.dispatcher.processor.util.*
 import java.util.*
+import javax.annotation.processing.Messager
 import javax.lang.model.element.ExecutableElement
 
 /**
@@ -14,7 +15,7 @@ import javax.lang.model.element.ExecutableElement
  * <p>
  * This generates the parts of code independent from specific permission method signatures for different target objects.
  */
-abstract class KotlinBaseProcessorUnit : KtProcessorUnit {
+abstract class KotlinBaseProcessorUnit(val messager: Messager) : KtProcessorUnit {
 
     protected val PERMISSION_UTILS = ClassName("permissions.dispatcher", "PermissionUtils")
     private val BUILD = ClassName("android.os", "Build")

--- a/processor/src/main/kotlin/permissions/dispatcher/processor/impl/kotlin/KotlinBaseProcessorUnit.kt
+++ b/processor/src/main/kotlin/permissions/dispatcher/processor/impl/kotlin/KotlinBaseProcessorUnit.kt
@@ -99,8 +99,8 @@ abstract class KotlinBaseProcessorUnit(val messager: Messager) : KtProcessorUnit
                 .receiver(rpe.ktTypeName)
 
         // If the method has parameters, add those as well
-        method.parameters.forEach {
-            builder.addParameter(it.simpleString(), it.asType().asTypeName().checkStringType())
+        method.parameters.forEach { param ->
+            builder.addParameter(param.simpleString(), param.asPreparedType())
         }
 
         // Delegate method body generation to implementing classes
@@ -356,7 +356,7 @@ abstract class KotlinBaseProcessorUnit(val messager: Messager) : KtProcessorUnit
 
         needsMethod.parameters.forEach {
             builder.addProperty(
-                    PropertySpec.builder(it.simpleString(), it.asType().asTypeName().checkStringType(), KModifier.PRIVATE)
+                    PropertySpec.builder(it.simpleString(), it.asPreparedType(), KModifier.PRIVATE)
                             .initializer(CodeBlock.of(it.simpleString()))
                             .build()
             )
@@ -366,7 +366,7 @@ abstract class KotlinBaseProcessorUnit(val messager: Messager) : KtProcessorUnit
         val targetParam = "target"
         val constructorSpec = FunSpec.constructorBuilder().addParameter(targetParam, rpe.ktTypeName)
         needsMethod.parameters.forEach {
-            constructorSpec.addParameter(it.simpleString(), it.asType().asTypeName().checkStringType(), KModifier.PRIVATE)
+            constructorSpec.addParameter(it.simpleString(), it.asPreparedType(), KModifier.PRIVATE)
         }
         builder.primaryConstructor(constructorSpec.build())
 

--- a/processor/src/main/kotlin/permissions/dispatcher/processor/impl/kotlin/KotlinNativeFragmentProcessorUnit.kt
+++ b/processor/src/main/kotlin/permissions/dispatcher/processor/impl/kotlin/KotlinNativeFragmentProcessorUnit.kt
@@ -2,9 +2,10 @@ package permissions.dispatcher.processor.impl.kotlin
 
 import com.squareup.kotlinpoet.FunSpec
 import permissions.dispatcher.processor.util.*
+import javax.annotation.processing.Messager
 import javax.lang.model.type.TypeMirror
 
-class KotlinNativeFragmentProcessorUnit : KotlinBaseProcessorUnit() {
+class KotlinNativeFragmentProcessorUnit(messager: Messager) : KotlinBaseProcessorUnit(messager) {
 
     override fun getTargetType(): TypeMirror = typeMirrorOf("android.app.Fragment")
 

--- a/processor/src/main/kotlin/permissions/dispatcher/processor/impl/kotlin/KotlinSupportFragmentProcessorUnit.kt
+++ b/processor/src/main/kotlin/permissions/dispatcher/processor/impl/kotlin/KotlinSupportFragmentProcessorUnit.kt
@@ -2,12 +2,13 @@ package permissions.dispatcher.processor.impl.kotlin
 
 import com.squareup.kotlinpoet.FunSpec
 import permissions.dispatcher.processor.util.*
+import javax.annotation.processing.Messager
 import javax.lang.model.type.TypeMirror
 
 /**
  * [permissions.dispatcher.processor.KtProcessorUnit] implementation for Fragments defined in the support-v4 library.
  */
-class KotlinSupportFragmentProcessorUnit : KotlinBaseProcessorUnit() {
+class KotlinSupportFragmentProcessorUnit(messager: Messager) : KotlinBaseProcessorUnit(messager) {
 
     override fun getTargetType(): TypeMirror = typeMirrorOf("android.support.v4.app.Fragment")
 

--- a/processor/src/main/kotlin/permissions/dispatcher/processor/util/Extensions.kt
+++ b/processor/src/main/kotlin/permissions/dispatcher/processor/util/Extensions.kt
@@ -65,7 +65,7 @@ fun VariableElement.isNullable(): Boolean =
 fun VariableElement.asPreparedType(): TypeName =
         this.asType()
                 .asTypeName()
-                .mapPrimitivesToKotlinTypes()
+                .checkStringType()
                 .mapToNullableTypeIf(this.isNullable())
 
 /**
@@ -115,16 +115,8 @@ fun FileSpec.Builder.addTypes(types: List<TypeSpec>): FileSpec.Builder {
  * To avoid KotlinPoet bug that returns java.lang.String when type name is kotlin.String.
  * This method should be removed after addressing on KotlinPoet side.
  */
-fun TypeName.mapPrimitivesToKotlinTypes() =
-        when (this.toString()) {
-            "java.lang.String" -> ClassName("kotlin", "String")
-            "java.lang.Integer" -> ClassName("kotlin", "Int")
-            "java.lang.Float" -> ClassName("kotlin", "Float")
-            "java.lang.Double" -> ClassName("kotlin", "Double")
-            "java.lang.Char" -> ClassName("kotlin", "Char")
-            "java.lang.Boolean" -> ClassName("kotlin", "Boolean")
-            else -> this
-        }
+fun TypeName.checkStringType() =
+        if (this.toString() == "java.lang.String") ClassName("kotlin", "String") else this
 
 /**
  * Returns this TypeName as nullable or non-nullable based on the given condition.

--- a/test-v13/src/main/java/permissions/dispatcher/test_v13/FragmentWithAllAnnotationsKt.kt
+++ b/test-v13/src/main/java/permissions/dispatcher/test_v13/FragmentWithAllAnnotationsKt.kt
@@ -17,6 +17,10 @@ open class FragmentWithAllAnnotationsKt : Fragment() {
     fun showCamera() {
     }
 
+    @NeedsPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+    fun accessLocation(location: String?) {
+    }
+
     @OnShowRationale(Manifest.permission.CAMERA)
     fun showRationaleForCamera(request: PermissionRequest?) {
     }

--- a/test-v13/src/test/java/permissions/dispatcher/test_v13/FragmentWithAllAnnotationsKtPermissionsDispatcherTest.kt
+++ b/test-v13/src/test/java/permissions/dispatcher/test_v13/FragmentWithAllAnnotationsKtPermissionsDispatcherTest.kt
@@ -12,6 +12,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Matchers.any
+import org.mockito.Matchers.anyString
 import org.mockito.Mockito
 import org.powermock.api.mockito.PowerMockito
 import org.powermock.core.classloader.annotations.PowerMockIgnore
@@ -91,6 +92,16 @@ class FragmentWithAllAnnotationsKtPermissionsDispatcherTest {
         fragment.showCameraWithPermissionCheck()
 
         Mockito.verify(fragment, Mockito.times(0)).showRationaleForCamera(any(PermissionRequest::class.java))
+    }
+
+    @Test
+    fun `a method with nullable parameters is properly generated`() {
+        mockCheckSelfPermission(true)
+
+        fragment.accessLocationWithPermissionCheck("something")
+        fragment.accessLocationWithPermissionCheck(null)
+
+        Mockito.verify(fragment, Mockito.times(2)).accessLocation(anyString())
     }
 
     @Test


### PR DESCRIPTION
Generated Kotlin code needs to honor nullable parameters in the signatures of annotated `@NeedsPermission` methods:

```kotlin
@RuntimePermissions
class SomeActivity : AppCompatActivity() {
  @NeedsPermission(Manifest.permission.ACCESS_FINE_LOCATION)
  fun updateLocation(currentLocation: LatLng?) {
    // ...
  }
}

// Wrong
fun SomeActivity.updateLocationWithPermissionCheck(currentLocation: LatLng) {
}

// Correct
fun SomeActivity.updateLocationWithPermissionCheck(currentLocation: LatLng?) {
}
```

As part of the Parameter-to-TypeName chain, we now inspect the annotations of a `VariableElement` & attach the nullability information to its `TypeName` via a new extension method, `mapToNullableTypeIf(Boolean)`. Since we use this chain in multiple places, I have extracted this mapping into its own function, `VariableElement#asPreparedType()`.

This fixes #397.