### PR TITLE
Fix the problem with NoClassDefFoundError

### DIFF
--- a/lint/src/main/java/permissions/dispatcher/CallOnRequestPermissionsResultDetector.java
+++ b/lint/src/main/java/permissions/dispatcher/CallOnRequestPermissionsResultDetector.java
@@ -104,7 +104,15 @@ public final class CallOnRequestPermissionsResultDetector extends Detector imple
                         continue;
                     }
 
-                    if (referenceExpression instanceof KotlinUQualifiedReferenceExpression) {
+                    boolean isKotlin = false;
+
+                    try {
+                        if (referenceExpression instanceof KotlinUQualifiedReferenceExpression) {
+                            isKotlin = true;
+                        }
+                    } catch (NoClassDefFoundError ignored) {}
+
+                    if (isKotlin) {
                         if ("onRequestPermissionsResult".equals(referenceExpression.getResolvedName())) {
                             return true;
                         }


### PR DESCRIPTION
It seems if the project is only consist Java, then `KotlinUQualifiedReferenceExpression` become `NoClassDefFoundError`. 

TBH, I can't find a best way to fix this problem. 