### PR TITLE
Fix the problem with order matter "Useless @OnShowRationale declaration"

### DIFF
--- a/lint/src/main/java/permissions/dispatcher/NoCorrespondingNeedsPermissionDetector.java
+++ b/lint/src/main/java/permissions/dispatcher/NoCorrespondingNeedsPermissionDetector.java
@@ -75,6 +75,11 @@ public final class NoCorrespondingNeedsPermissionDetector extends Detector imple
             if (onShowRationaleAnnotations.isEmpty()) {
                 return true;
             }
+            return true;
+        }
+
+        @Override
+        public void afterVisitClass(UClass node) {
             // If there is OnShowRationale, find corresponding NeedsPermission
             for (UAnnotation onShowRationaleAnnotation : onShowRationaleAnnotations) {
                 boolean found = false;
@@ -87,7 +92,6 @@ public final class NoCorrespondingNeedsPermissionDetector extends Detector imple
                     context.report(ISSUE, context.getLocation(onShowRationaleAnnotation), "Useless @OnShowRationale declaration");
                 }
             }
-            return true;
         }
 
         private static boolean hasSameNodes(List<UNamedExpression> first, List<UNamedExpression> second) {

--- a/lint/src/test/java/permissions/dispatcher/NoCorrespondingNeedsPermissionDetectorKtTest.kt
+++ b/lint/src/test/java/permissions/dispatcher/NoCorrespondingNeedsPermissionDetectorKtTest.kt
@@ -40,6 +40,33 @@ class NoCorrespondingNeedsPermissionDetectorKtTest {
 
     @Test
     @Throws(Exception::class)
+    fun noNeedsPermissionAnnotationNoErrorsOrderNotMatter() {
+        @Language("kotlin") val foo = """
+                package permissions.dispatcher
+
+                class Foo {
+                    @OnShowRationale("Camera")
+                    fun someMethod() {
+                    }
+
+                    @NeedsPermission("Camera")
+                    fun showCamera() {
+                    }
+                }
+                """.trimMargin()
+
+        lint()
+                .files(
+                        java(onNeedsPermission),
+                        java(onRationaleAnnotation),
+                        kt(foo))
+                .issues(NoCorrespondingNeedsPermissionDetector.ISSUE)
+                .run()
+                .expectClean()
+    }
+
+    @Test
+    @Throws(Exception::class)
     fun noNeedsPermissionAnnotation() {
         @Language("kotlin") val foo = """
                 package permissions.dispatcher

--- a/lint/src/test/java/permissions/dispatcher/NoCorrespondingNeedsPermissionDetectorTest.kt
+++ b/lint/src/test/java/permissions/dispatcher/NoCorrespondingNeedsPermissionDetectorTest.kt
@@ -39,6 +39,33 @@ class NoCorrespondingNeedsPermissionDetectorTest {
 
     @Test
     @Throws(Exception::class)
+    fun noNeedsPermissionAnnotationNoErrorsOrderNoTMatter() {
+        @Language("JAVA") val foo = """
+                package permissions.dispatcher;
+
+                public class Foo {
+                    @OnShowRationale("Camera")
+                    void someMethod() {
+                    }
+
+                    @NeedsPermission("Camera")
+                    void showCamera() {
+                    }
+                }
+                """.trimMargin()
+
+        lint()
+                .files(
+                        java(onNeedsPermission),
+                        java(onRationaleAnnotation),
+                        java(foo))
+                .issues(NoCorrespondingNeedsPermissionDetector.ISSUE)
+                .run()
+                .expectClean()
+    }
+
+    @Test
+    @Throws(Exception::class)
     fun noNeedsPermissionAnnotation() {
         @Language("JAVA") val foo = """
                 package permissions.dispatcher;


### PR DESCRIPTION
The problem is it validated each time lint found annotation. This commit
make lint validate the annotation at afterVisitClass since at the point,
all annotations are stored into needsPermissionsAnnotations and
onShowRationaleAnnotations variables.

Close #407 