### PR TITLE
Make CI stable, again

### DIFF
--- a/test-v13/build.gradle
+++ b/test-v13/build.gradle
@@ -24,6 +24,17 @@ android {
     sourceSets {
         main.java.srcDirs += "src/main/kotlin"
     }
+
+    testOptions {
+        unitTests.all {
+            testLogging {
+                events "passed", "failed", "standardOut", "standardError"
+                outputs.upToDateWhen {false}
+                showStandardStreams = true
+                exceptionFormat "full"
+            }
+        }
+    }
 }
 
 dependencies {

--- a/test-v13/src/test/java/permissions/dispatcher/test_v13/Extensions.kt
+++ b/test-v13/src/test/java/permissions/dispatcher/test_v13/Extensions.kt
@@ -53,6 +53,10 @@ fun overwriteCustomManufacture(manufactureText: String = "Xiaomi") {
     manufacture.set(null, manufactureText)
 }
 
+fun clearCustomManufacture() {
+    overwriteCustomManufacture("")
+}
+
 fun overwriteCustomSdkInt(sdkInt: Int = 23) {
     val modifiersField = Field::class.java.getDeclaredField("modifiers")
     modifiersField.isAccessible = true
@@ -61,6 +65,10 @@ fun overwriteCustomSdkInt(sdkInt: Int = 23) {
     field.isAccessible = true
     modifiersField.setInt(field, field.modifiers and Modifier.FINAL.inv())
     field.set(null, sdkInt)
+}
+
+fun clearCustomSdkInt() {
+    overwriteCustomSdkInt()
 }
 
 fun testForXiaomi() {

--- a/test-v13/src/test/java/permissions/dispatcher/test_v13/FragmentWithAllAnnotationsKtPermissionsDispatcherTest.kt
+++ b/test-v13/src/test/java/permissions/dispatcher/test_v13/FragmentWithAllAnnotationsKtPermissionsDispatcherTest.kt
@@ -6,10 +6,7 @@ import android.support.v13.app.FragmentCompat
 import android.support.v4.app.AppOpsManagerCompat
 import android.support.v4.content.PermissionChecker
 import android.support.v7.app.AppCompatActivity
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Rule
-import org.junit.Test
+import org.junit.*
 import org.junit.runner.RunWith
 import org.mockito.Matchers.any
 import org.mockito.Matchers.anyString
@@ -53,6 +50,12 @@ class FragmentWithAllAnnotationsKtPermissionsDispatcherTest {
         PowerMockito.mockStatic(FragmentCompat::class.java)
         PowerMockito.mockStatic(Process::class.java)
         PowerMockito.mockStatic(AppOpsManagerCompat::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        clearCustomManufacture()
+        clearCustomSdkInt()
     }
 
     @Test

--- a/test-v13/src/test/java/permissions/dispatcher/test_v13/FragmentWithAllAnnotationsPermissionsDispatcherTest.kt
+++ b/test-v13/src/test/java/permissions/dispatcher/test_v13/FragmentWithAllAnnotationsPermissionsDispatcherTest.kt
@@ -6,10 +6,7 @@ import android.support.v13.app.FragmentCompat
 import android.support.v4.app.AppOpsManagerCompat
 import android.support.v4.content.PermissionChecker
 import android.support.v7.app.AppCompatActivity
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Rule
-import org.junit.Test
+import org.junit.*
 import org.junit.runner.RunWith
 import org.mockito.Matchers.any
 import org.mockito.Mockito
@@ -51,6 +48,12 @@ class FragmentWithAllAnnotationsPermissionsDispatcherTest {
         PowerMockito.mockStatic(FragmentCompat::class.java)
         PowerMockito.mockStatic(Process::class.java)
         PowerMockito.mockStatic(AppOpsManagerCompat::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        clearCustomManufacture()
+        clearCustomSdkInt()
     }
 
     @Test

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -21,6 +21,17 @@ android {
     sourceSets {
         main.java.srcDirs += "src/main/kotlin"
     }
+
+    testOptions {
+        unitTests.all {
+            testLogging {
+                events "passed", "failed", "standardOut", "standardError"
+                outputs.upToDateWhen {false}
+                showStandardStreams = true
+                exceptionFormat "full"
+            }
+        }
+    }
 }
 
 dependencies {

--- a/test/src/test/java/permissions/dispatcher/test/ActivityOnlyNeedsPermissionPermissionsDispatcherTest.kt
+++ b/test/src/test/java/permissions/dispatcher/test/ActivityOnlyNeedsPermissionPermissionsDispatcherTest.kt
@@ -5,6 +5,7 @@ import android.os.Process
 import android.support.v4.app.ActivityCompat
 import android.support.v4.app.AppOpsManagerCompat
 import android.support.v4.content.PermissionChecker
+import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -38,6 +39,12 @@ class ActivityOnlyNeedsPermissionPermissionsDispatcherTest {
         PowerMockito.mockStatic(PermissionChecker::class.java)
         PowerMockito.mockStatic(Process::class.java)
         PowerMockito.mockStatic(AppOpsManagerCompat::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        clearCustomManufacture()
+        clearCustomSdkInt()
     }
 
     @Test

--- a/test/src/test/java/permissions/dispatcher/test/ActivityWithAllAnnotationsKtPermissionsDispatcherTest.kt
+++ b/test/src/test/java/permissions/dispatcher/test/ActivityWithAllAnnotationsKtPermissionsDispatcherTest.kt
@@ -5,6 +5,7 @@ import android.os.Process
 import android.support.v4.app.ActivityCompat
 import android.support.v4.app.AppOpsManagerCompat
 import android.support.v4.content.PermissionChecker
+import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -43,6 +44,12 @@ class ActivityWithAllAnnotationsKtPermissionsDispatcherTest {
         PowerMockito.mockStatic(PermissionChecker::class.java)
         PowerMockito.mockStatic(Process::class.java)
         PowerMockito.mockStatic(AppOpsManagerCompat::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        clearCustomManufacture()
+        clearCustomSdkInt()
     }
 
     @Test

--- a/test/src/test/java/permissions/dispatcher/test/ActivityWithAllAnnotationsPermissionsDispatcherTest.kt
+++ b/test/src/test/java/permissions/dispatcher/test/ActivityWithAllAnnotationsPermissionsDispatcherTest.kt
@@ -5,6 +5,7 @@ import android.os.Process
 import android.support.v4.app.ActivityCompat
 import android.support.v4.app.AppOpsManagerCompat
 import android.support.v4.content.PermissionChecker
+import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -40,6 +41,12 @@ class ActivityWithAllAnnotationsPermissionsDispatcherTest {
         PowerMockito.mockStatic(PermissionChecker::class.java)
         PowerMockito.mockStatic(Process::class.java)
         PowerMockito.mockStatic(AppOpsManagerCompat::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        clearCustomManufacture()
+        clearCustomSdkInt()
     }
 
     @Test

--- a/test/src/test/java/permissions/dispatcher/test/ActivityWithOnNeverAskAgainPermissionsDispatcherTest.kt
+++ b/test/src/test/java/permissions/dispatcher/test/ActivityWithOnNeverAskAgainPermissionsDispatcherTest.kt
@@ -5,6 +5,7 @@ import android.os.Process
 import android.support.v4.app.ActivityCompat
 import android.support.v4.app.AppOpsManagerCompat
 import android.support.v4.content.PermissionChecker
+import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -37,6 +38,12 @@ class ActivityWithOnNeverAskAgainPermissionsDispatcherTest {
         PowerMockito.mockStatic(PermissionChecker::class.java)
         PowerMockito.mockStatic(Process::class.java)
         PowerMockito.mockStatic(AppOpsManagerCompat::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        clearCustomManufacture()
+        clearCustomSdkInt()
     }
 
     @Test

--- a/test/src/test/java/permissions/dispatcher/test/ActivityWithOnPermissionDeniedPermissionsDispatcherTest.kt
+++ b/test/src/test/java/permissions/dispatcher/test/ActivityWithOnPermissionDeniedPermissionsDispatcherTest.kt
@@ -5,6 +5,7 @@ import android.os.Process
 import android.support.v4.app.ActivityCompat
 import android.support.v4.app.AppOpsManagerCompat
 import android.support.v4.content.PermissionChecker
+import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -37,6 +38,12 @@ class ActivityWithOnPermissionDeniedPermissionsDispatcherTest {
         PowerMockito.mockStatic(PermissionChecker::class.java)
         PowerMockito.mockStatic(Process::class.java)
         PowerMockito.mockStatic(AppOpsManagerCompat::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        clearCustomManufacture()
+        clearCustomSdkInt()
     }
 
     @Test

--- a/test/src/test/java/permissions/dispatcher/test/ActivityWithShowRationalePermissionsDispatcherTest.kt
+++ b/test/src/test/java/permissions/dispatcher/test/ActivityWithShowRationalePermissionsDispatcherTest.kt
@@ -5,6 +5,7 @@ import android.os.Process
 import android.support.v4.app.ActivityCompat
 import android.support.v4.app.AppOpsManagerCompat
 import android.support.v4.content.PermissionChecker
+import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -40,6 +41,12 @@ class ActivityWithShowRationalePermissionsDispatcherTest {
         PowerMockito.mockStatic(PermissionChecker::class.java)
         PowerMockito.mockStatic(Process::class.java)
         PowerMockito.mockStatic(AppOpsManagerCompat::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        clearCustomManufacture()
+        clearCustomSdkInt()
     }
 
     @Test

--- a/test/src/test/java/permissions/dispatcher/test/ActivityWithSystemAlertWindowAllAnnotationsPermissionsDispatcherTest.kt
+++ b/test/src/test/java/permissions/dispatcher/test/ActivityWithSystemAlertWindowAllAnnotationsPermissionsDispatcherTest.kt
@@ -8,6 +8,7 @@ import android.provider.Settings
 import android.support.v4.app.ActivityCompat
 import android.support.v4.app.AppOpsManagerCompat
 import android.support.v4.content.PermissionChecker
+import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -50,6 +51,12 @@ class ActivityWithSystemAlertWindowAllAnnotationsPermissionsDispatcherTest {
 
         PowerMockito.mockStatic(Build.VERSION::class.java)
         PowerMockito.field(Build.VERSION::class.java, "SDK_INT").setInt(null, 25)
+    }
+
+    @After
+    fun tearDown() {
+        clearCustomManufacture()
+        clearCustomSdkInt()
     }
 
     @Test

--- a/test/src/test/java/permissions/dispatcher/test/ActivityWithSystemAlertWindowKtAllAnnotationsTest.kt
+++ b/test/src/test/java/permissions/dispatcher/test/ActivityWithSystemAlertWindowKtAllAnnotationsTest.kt
@@ -8,6 +8,7 @@ import android.provider.Settings
 import android.support.v4.app.ActivityCompat
 import android.support.v4.app.AppOpsManagerCompat
 import android.support.v4.content.PermissionChecker
+import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -50,6 +51,12 @@ class ActivityWithSystemAlertWindowKtAllAnnotationsTest {
 
         PowerMockito.mockStatic(Build.VERSION::class.java)
         PowerMockito.field(Build.VERSION::class.java, "SDK_INT").setInt(null, 25)
+    }
+
+    @After
+    fun tearDown() {
+        clearCustomManufacture()
+        clearCustomSdkInt()
     }
 
     @Test

--- a/test/src/test/java/permissions/dispatcher/test/ActivityWithSystemAlertWindowKtTest.kt
+++ b/test/src/test/java/permissions/dispatcher/test/ActivityWithSystemAlertWindowKtTest.kt
@@ -8,6 +8,7 @@ import android.provider.Settings
 import android.support.v4.app.ActivityCompat
 import android.support.v4.app.AppOpsManagerCompat
 import android.support.v4.content.PermissionChecker
+import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -48,6 +49,12 @@ class ActivityWithSystemAlertWindowKtTest {
 
         PowerMockito.mockStatic(Build.VERSION::class.java)
         PowerMockito.field(Build.VERSION::class.java, "SDK_INT").setInt(null, 25)
+    }
+
+    @After
+    fun tearDown() {
+        clearCustomManufacture()
+        clearCustomSdkInt()
     }
 
     @Test

--- a/test/src/test/java/permissions/dispatcher/test/ActivityWithSystemAlertWindowPermissionsDispatcherTest.kt
+++ b/test/src/test/java/permissions/dispatcher/test/ActivityWithSystemAlertWindowPermissionsDispatcherTest.kt
@@ -8,6 +8,7 @@ import android.provider.Settings
 import android.support.v4.app.ActivityCompat
 import android.support.v4.app.AppOpsManagerCompat
 import android.support.v4.content.PermissionChecker
+import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -47,6 +48,12 @@ class ActivityWithSystemAlertWindowPermissionsDispatcherTest {
 
         PowerMockito.mockStatic(Build.VERSION::class.java)
         PowerMockito.field(Build.VERSION::class.java, "SDK_INT").setInt(null, 25)
+    }
+
+    @After
+    fun tearDown() {
+        clearCustomManufacture()
+        clearCustomSdkInt()
     }
 
     @Test

--- a/test/src/test/java/permissions/dispatcher/test/ActivityWithWriteSettingAllAnnotationsPermissionsDispatcherTest.kt
+++ b/test/src/test/java/permissions/dispatcher/test/ActivityWithWriteSettingAllAnnotationsPermissionsDispatcherTest.kt
@@ -8,6 +8,7 @@ import android.provider.Settings
 import android.support.v4.app.ActivityCompat
 import android.support.v4.app.AppOpsManagerCompat
 import android.support.v4.content.PermissionChecker
+import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -48,6 +49,12 @@ class ActivityWithWriteSettingAllAnnotationsPermissionsDispatcherTest {
 
         PowerMockito.mockStatic(Build.VERSION::class.java)
         PowerMockito.field(Build.VERSION::class.java, "SDK_INT").setInt(null, 25)
+    }
+
+    @After
+    fun tearDown() {
+        clearCustomManufacture()
+        clearCustomSdkInt()
     }
 
     @Test

--- a/test/src/test/java/permissions/dispatcher/test/ActivityWithWriteSettingKtAllAnnotationsTest.kt
+++ b/test/src/test/java/permissions/dispatcher/test/ActivityWithWriteSettingKtAllAnnotationsTest.kt
@@ -8,6 +8,7 @@ import android.provider.Settings
 import android.support.v4.app.ActivityCompat
 import android.support.v4.app.AppOpsManagerCompat
 import android.support.v4.content.PermissionChecker
+import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -50,6 +51,12 @@ class ActivityWithWriteSettingKtAllAnnotationsTest {
 
         PowerMockito.mockStatic(Build.VERSION::class.java)
         PowerMockito.field(Build.VERSION::class.java, "SDK_INT").setInt(null, 25)
+    }
+
+    @After
+    fun tearDown() {
+        clearCustomManufacture()
+        clearCustomSdkInt()
     }
 
     @Test

--- a/test/src/test/java/permissions/dispatcher/test/ActivityWithWriteSettingKtTest.kt
+++ b/test/src/test/java/permissions/dispatcher/test/ActivityWithWriteSettingKtTest.kt
@@ -8,6 +8,7 @@ import android.provider.Settings
 import android.support.v4.app.ActivityCompat
 import android.support.v4.app.AppOpsManagerCompat
 import android.support.v4.content.PermissionChecker
+import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -48,6 +49,12 @@ class ActivityWithWriteSettingKtTest {
 
         PowerMockito.mockStatic(Build.VERSION::class.java)
         PowerMockito.field(Build.VERSION::class.java, "SDK_INT").setInt(null, 25)
+    }
+
+    @After
+    fun tearDown() {
+        clearCustomManufacture()
+        clearCustomSdkInt()
     }
 
     @Test

--- a/test/src/test/java/permissions/dispatcher/test/ActivityWithWriteSettingPermissionsDispatcherTest.kt
+++ b/test/src/test/java/permissions/dispatcher/test/ActivityWithWriteSettingPermissionsDispatcherTest.kt
@@ -8,6 +8,7 @@ import android.provider.Settings
 import android.support.v4.app.ActivityCompat
 import android.support.v4.app.AppOpsManagerCompat
 import android.support.v4.content.PermissionChecker
+import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -47,6 +48,12 @@ class ActivityWithWriteSettingPermissionsDispatcherTest {
 
         PowerMockito.mockStatic(Build.VERSION::class.java)
         PowerMockito.field(Build.VERSION::class.java, "SDK_INT").setInt(null, 25)
+    }
+
+    @After
+    fun tearDown() {
+        clearCustomManufacture()
+        clearCustomSdkInt()
     }
 
     @Test

--- a/test/src/test/java/permissions/dispatcher/test/Extensions.kt
+++ b/test/src/test/java/permissions/dispatcher/test/Extensions.kt
@@ -80,6 +80,10 @@ fun overwriteCustomManufacture(manufactureText: String = "Xiaomi") {
     manufacture.set(null, manufactureText)
 }
 
+fun clearCustomManufacture() {
+    overwriteCustomManufacture("")
+}
+
 fun overwriteCustomSdkInt(sdkInt: Int = 23) {
     val modifiersField = Field::class.java.getDeclaredField("modifiers")
     modifiersField.isAccessible = true
@@ -88,6 +92,10 @@ fun overwriteCustomSdkInt(sdkInt: Int = 23) {
     field.isAccessible = true
     modifiersField.setInt(field, field.modifiers and Modifier.FINAL.inv())
     field.set(null, sdkInt)
+}
+
+fun clearCustomSdkInt() {
+    overwriteCustomSdkInt()
 }
 
 fun testForXiaomi() {

--- a/test/src/test/java/permissions/dispatcher/test/SupportFragmentWithAllAnnotationsKtPermissionsDispatcherTest.kt
+++ b/test/src/test/java/permissions/dispatcher/test/SupportFragmentWithAllAnnotationsKtPermissionsDispatcherTest.kt
@@ -5,6 +5,7 @@ import android.os.Process
 import android.support.v4.app.AppOpsManagerCompat
 import android.support.v4.content.PermissionChecker
 import android.support.v7.app.AppCompatActivity
+import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -43,6 +44,12 @@ class SupportFragmentWithAllAnnotationsKtPermissionsDispatcherTest {
         PowerMockito.mockStatic(PermissionChecker::class.java)
         PowerMockito.mockStatic(Process::class.java)
         PowerMockito.mockStatic(AppOpsManagerCompat::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        clearCustomManufacture()
+        clearCustomSdkInt()
     }
 
     @Test

--- a/test/src/test/java/permissions/dispatcher/test/SupportFragmentWithAllAnnotationsPermissionsDispatcherTest.kt
+++ b/test/src/test/java/permissions/dispatcher/test/SupportFragmentWithAllAnnotationsPermissionsDispatcherTest.kt
@@ -5,6 +5,7 @@ import android.os.Process
 import android.support.v4.app.AppOpsManagerCompat
 import android.support.v4.content.PermissionChecker
 import android.support.v7.app.AppCompatActivity
+import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -42,6 +43,12 @@ class SupportFragmentWithAllAnnotationsPermissionsDispatcherTest {
         PowerMockito.mockStatic(PermissionChecker::class.java)
         PowerMockito.mockStatic(Process::class.java)
         PowerMockito.mockStatic(AppOpsManagerCompat::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        clearCustomManufacture()
+        clearCustomSdkInt()
     }
 
     @Test


### PR DESCRIPTION
The problem was it set `Build.MANIFACTURE` using reflection https://github.com/permissions-dispatcher/PermissionsDispatcher/blob/980c35ed396ce7d896c69b2b862923e38b7af11f/test/src/test/java/permissions/dispatcher/test/Extensions.kt#L73-L81 and did not clear the value. So, that since `Build.MANIFACTURE` is xiaomi, https://github.com/permissions-dispatcher/PermissionsDispatcher/blob/39c665901c0b293182be8b236a1524807dbca2b1/library/src/main/java/permissions/dispatcher/PermissionUtils.java#L94-L97 `hasSelfPermissionForXiaomi` get called and the tests fail.

This happens when xiaomi related tests get executed before testing OnShowRationale related tests.

You can reproduce this issue in local machine if https://github.com/permissions-dispatcher/PermissionsDispatcher/blob/f0f55196dea473eb9dbe729f0635c4da8fde6577/test/src/test/java/permissions/dispatcher/test/ActivityOnlyNeedsPermissionPermissionsDispatcherTest.kt#L93-L102 move to top of the test methods. (I cannot use `FixMethodOrder` to force the test order to reproduce this issue because the tests uses PowerMock.)
 
Close #455 