### PR TITLE
Conductor support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,6 +28,7 @@ COMPILE_TESTING_VERSION = 0.12
 LINT_VERSION            = 26.2.0-alpha06
 ROBOLECTRIC_VERSION     = 3.3.2
 COMMONS_IO_VERSION      = 2.6
+CONDUCTOR_VERSION       = 2.1.5
 
 # Android configuration
 COMPILE_SDK_VERSION     = android-28

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     testCompile androidJar()
     testCompile files(Jvm.current().getToolsJar())
     testCompileAar "androidx.legacy:legacy-support-v4:$ANDROIDX_LIBRARY_VERSION"
+    testCompileAar "com.bluelinelabs:conductor:$CONDUCTOR_VERSION"
     testCompileAar project(path: ":library", configuration: "default")
 }
 

--- a/processor/src/main/kotlin/permissions/dispatcher/processor/exception/WrongClassException.kt
+++ b/processor/src/main/kotlin/permissions/dispatcher/processor/exception/WrongClassException.kt
@@ -3,4 +3,4 @@ package permissions.dispatcher.processor.exception
 import com.squareup.javapoet.TypeName
 import javax.lang.model.type.TypeMirror
 
-class WrongClassException(type: TypeMirror) : RuntimeException("Class '${TypeName.get(type).toString()}' can't be annotated with '@RuntimePermissions'")
+class WrongClassException(type: TypeMirror) : RuntimeException("Class '${TypeName.get(type)}' can't be annotated with '@RuntimePermissions'")

--- a/processor/src/main/kotlin/permissions/dispatcher/processor/impl/ProcessorUnits.kt
+++ b/processor/src/main/kotlin/permissions/dispatcher/processor/impl/ProcessorUnits.kt
@@ -1,9 +1,11 @@
 package permissions.dispatcher.processor.impl
 
 import permissions.dispatcher.processor.impl.java.JavaActivityProcessorUnit
+import permissions.dispatcher.processor.impl.java.JavaConductorProcessorUnit
 import permissions.dispatcher.processor.impl.java.JavaFragmentProcessorUnit
 import permissions.dispatcher.processor.impl.kotlin.KotlinActivityProcessorUnit
+import permissions.dispatcher.processor.impl.kotlin.KotlinConductorProcessorUnit
 import permissions.dispatcher.processor.impl.kotlin.KotlinFragmentProcessorUnit
 
-val javaProcessorUnits = listOf(JavaActivityProcessorUnit(), JavaFragmentProcessorUnit())
-val kotlinProcessorUnits = listOf(KotlinActivityProcessorUnit(), KotlinFragmentProcessorUnit())
+val javaProcessorUnits = listOf(JavaActivityProcessorUnit(), JavaFragmentProcessorUnit(), JavaConductorProcessorUnit())
+val kotlinProcessorUnits = listOf(KotlinActivityProcessorUnit(), KotlinFragmentProcessorUnit(), KotlinConductorProcessorUnit())

--- a/processor/src/main/kotlin/permissions/dispatcher/processor/impl/java/JavaConductorProcessorUnit.kt
+++ b/processor/src/main/kotlin/permissions/dispatcher/processor/impl/java/JavaConductorProcessorUnit.kt
@@ -1,0 +1,22 @@
+package permissions.dispatcher.processor.impl.java
+
+import com.squareup.javapoet.MethodSpec
+import permissions.dispatcher.processor.util.typeMirrorOf
+import javax.lang.model.type.TypeMirror
+
+class JavaConductorProcessorUnit() : JavaBaseProcessorUnit() {
+
+    override fun getTargetType(): TypeMirror = typeMirrorOf("com.bluelinelabs.conductor.Controller")
+
+    override fun getActivityName(targetParam: String): String = "$targetParam.getActivity()"
+
+    override fun addShouldShowRequestPermissionRationaleCondition(builder: MethodSpec.Builder, targetParam: String, permissionField: String, isPositiveCondition: Boolean) {
+        val condition = if (isPositiveCondition) "" else "!"
+        val activity = getActivityName(targetParam)
+        builder.beginControlFlow("if (\$N\$T.shouldShowRequestPermissionRationale(\$N, \$N))", condition, PERMISSION_UTILS, activity, permissionField)
+    }
+
+    override fun addRequestPermissionsStatement(builder: MethodSpec.Builder, targetParam: String, permissionField: String, requestCodeField: String) {
+        builder.addStatement("\$N.requestPermissions(\$N, \$N)", targetParam, permissionField, requestCodeField)
+    }
+}

--- a/processor/src/main/kotlin/permissions/dispatcher/processor/impl/kotlin/KotlinConductorProcessorUnit.kt
+++ b/processor/src/main/kotlin/permissions/dispatcher/processor/impl/kotlin/KotlinConductorProcessorUnit.kt
@@ -1,0 +1,22 @@
+package permissions.dispatcher.processor.impl.kotlin
+
+import com.squareup.kotlinpoet.FunSpec
+import permissions.dispatcher.processor.util.typeMirrorOf
+import javax.lang.model.type.TypeMirror
+
+class KotlinConductorProcessorUnit() : KotlinBaseProcessorUnit() {
+
+    override fun getTargetType(): TypeMirror = typeMirrorOf("com.bluelinelabs.conductor.Controller")
+
+    override fun getActivityName(targetParam: String): String = "$targetParam.getActivity()"
+
+    override fun addShouldShowRequestPermissionRationaleCondition(builder: FunSpec.Builder, permissionField: String, isPositiveCondition: Boolean) {
+        val condition = if (isPositiveCondition) "" else "!"
+        val activity = getActivityName("this")
+        builder.beginControlFlow("if (%N%T.shouldShowRequestPermissionRationale(%L, *%N))", condition, PERMISSION_UTILS, activity, permissionField)
+    }
+
+    override fun addRequestPermissionsStatement(builder: FunSpec.Builder, targetParam: String, permissionField: String, requestCodeField: String) {
+        builder.addStatement("%L.requestPermissions(%L, %N)", targetParam, permissionField, requestCodeField)
+    }
+}

--- a/processor/src/test/java/permissions/dispatcher/processor/ProcessorTestSuite.java
+++ b/processor/src/test/java/permissions/dispatcher/processor/ProcessorTestSuite.java
@@ -381,4 +381,8 @@ public class ProcessorTestSuite extends TestSuite {
     @Test public void onePermissionWithParamNoArgumentRationaleAndDeniedFragment() {
         assertJavaSource(Source.OnePermissionWithParamNoArgumentRationaleAndDeniedFragment);
     }
+
+    @Test public void onePermissionWithParamNoArgumentRationaleAndConductor() {
+        assertJavaSource(Source.OnePermissionWithParamNoArgumentRationaleAndConductor);
+    }
 }

--- a/processor/src/test/java/permissions/dispatcher/processor/data/Source.java
+++ b/processor/src/test/java/permissions/dispatcher/processor/data/Source.java
@@ -5970,4 +5970,93 @@ public final class Source {
             };
         }
     };
+
+    public static final BaseTest OnePermissionWithParamNoArgumentRationaleAndConductor = new BaseTest() {
+        @Override
+        protected String getName() {
+            return "MyController";
+        }
+
+        @Override
+        protected String[] getActualSource() {
+            return new String[]{
+                    "package tests;",
+                    "import android.Manifest;",
+                    "import androidx.annotation.NonNull;",
+                    "import android.view.LayoutInflater;",
+                    "import android.view.View;",
+                    "import android.view.ViewGroup;",
+                    "import com.bluelinelabs.conductor.Controller;",
+                    "import permissions.dispatcher.RuntimePermissions;",
+                    "import permissions.dispatcher.NeedsPermission;",
+                    "import permissions.dispatcher.OnShowRationale;",
+                    "import permissions.dispatcher.OnPermissionDenied;",
+                    "@RuntimePermissions",
+                    "public class MyController extends Controller {",
+                    "   @Override",
+                    "   protected View onCreateView(@NonNull LayoutInflater inflater, @NonNull ViewGroup container) {",
+                    "       return null;",
+                    "   }",
+                    "   @NeedsPermission(Manifest.permission.CAMERA)",
+                    "   void showCamera(String arg) {",
+                    "   }",
+                    "   @OnShowRationale(Manifest.permission.CAMERA)",
+                    "   void cameraRationale() {",
+                    "   }",
+                    "   @OnPermissionDenied(Manifest.permission.CAMERA)",
+                    "   void cameraDenied() {",
+                    "   }",
+                    "}"
+            };
+        }
+
+        @Override
+        protected String[] getExpectSource() {
+            return new String[]{
+                    "package tests;",
+                    "import androidx.annotation.NonNull;",
+                    "import java.lang.String;",
+                    "import permissions.dispatcher.PermissionUtils;",
+                    "final class MyControllerPermissionsDispatcher {",
+                    "   private static final int REQUEST_SHOWCAMERA = 0;",
+                    "   private static final String[] PERMISSION_SHOWCAMERA = new String[] {\"android.permission.CAMERA\"};",
+                    "   private static String showCameraArg;",
+                    "   private MyControllerPermissionsDispatcher() {",
+                    "   }",
+                    "   static void showCameraWithPermissionCheck(@NonNull MyController target, String arg) {",
+                    "       if (PermissionUtils.hasSelfPermissions(target.getActivity(), PERMISSION_SHOWCAMERA)) {",
+                    "           target.showCamera(arg);",
+                    "       } else {",
+                    "           showCameraArg = arg;",
+                    "           if (PermissionUtils.shouldShowRequestPermissionRationale(target.getActivity(), PERMISSION_SHOWCAMERA)) {",
+                    "               target.cameraRationale();",
+                    "           } else {",
+                    "               target.requestPermissions(PERMISSION_SHOWCAMERA, REQUEST_SHOWCAMERA);",
+                    "           }",
+                    "       }",
+                    "   }",
+                    "   static void proceedShowCameraPermissionRequest(@NonNull MyController target) {",
+                    "       target.requestPermissions(PERMISSION_SHOWCAMERA, REQUEST_SHOWCAMERA);",
+                    "   }",
+                    "   static void cancelShowCameraPermissionRequest(@NonNull MyController target) {",
+                    "       target.cameraDenied();",
+                    "   }",
+                    "   static void onRequestPermissionsResult(@NonNull MyController target, int requestCode, int[] grantResults) {",
+                    "       switch (requestCode) {",
+                    "           case REQUEST_SHOWCAMERA:",
+                    "               if (PermissionUtils.verifyPermissions(grantResults)) {",
+                    "                   target.showCamera(showCameraArg);",
+                    "               } else {",
+                    "                   target.cameraDenied();",
+                    "               }",
+                    "               showCameraArg = null;",
+                    "               break;",
+                    "           default:",
+                    "               break;",
+                    "       }",
+                    "   }",
+                    "}"
+            };
+        }
+    };
 }

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$KOTLIN_VERSION"
     implementation "androidx.appcompat:appcompat:$ANDROIDX_LIBRARY_VERSION"
+    implementation "com.bluelinelabs:conductor:$CONDUCTOR_VERSION"
 
     testImplementation "junit:junit:$JUNIT_VERSION"
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:1.3.11"

--- a/test/src/main/java/permissions/dispatcher/test/ConductorWithAllAnnotations.java
+++ b/test/src/main/java/permissions/dispatcher/test/ConductorWithAllAnnotations.java
@@ -1,0 +1,48 @@
+package permissions.dispatcher.test;
+
+import android.Manifest;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.bluelinelabs.conductor.Controller;
+
+import androidx.annotation.NonNull;
+import permissions.dispatcher.NeedsPermission;
+import permissions.dispatcher.OnNeverAskAgain;
+import permissions.dispatcher.OnPermissionDenied;
+import permissions.dispatcher.OnShowRationale;
+import permissions.dispatcher.PermissionRequest;
+import permissions.dispatcher.RuntimePermissions;
+
+@RuntimePermissions
+public class ConductorWithAllAnnotations extends Controller {
+
+    @NonNull
+    @Override
+    protected View onCreateView(@NonNull LayoutInflater inflater, @NonNull ViewGroup container) {
+        throw new IllegalArgumentException();
+    }
+
+    @NeedsPermission(Manifest.permission.CAMERA)
+    void showCamera() {
+    }
+
+    @OnShowRationale(Manifest.permission.CAMERA)
+    void showRationaleForCamera(final PermissionRequest request) {
+    }
+
+    @OnPermissionDenied(Manifest.permission.CAMERA)
+    void showDeniedForCamera() {
+    }
+
+    @OnNeverAskAgain(Manifest.permission.CAMERA)
+    void showNeverAskForCamera() {
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        ConductorWithAllAnnotationsPermissionsDispatcher.onRequestPermissionsResult(this, requestCode, grantResults);
+    }
+}

--- a/test/src/main/java/permissions/dispatcher/test/ConductorWithAllAnnotationsKt.kt
+++ b/test/src/main/java/permissions/dispatcher/test/ConductorWithAllAnnotationsKt.kt
@@ -1,0 +1,37 @@
+package permissions.dispatcher.test
+
+import android.Manifest
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.bluelinelabs.conductor.Controller
+import permissions.dispatcher.*
+
+@RuntimePermissions
+open class ConductorWithAllAnnotationsKt : Controller() {
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup): View {
+        throw IllegalArgumentException()
+    }
+
+    @NeedsPermission(Manifest.permission.CAMERA)
+    fun showCamera() {
+    }
+
+    @OnShowRationale(Manifest.permission.CAMERA)
+    fun showRationaleForCamera(request: PermissionRequest?) {
+    }
+
+    @OnPermissionDenied(Manifest.permission.CAMERA)
+    fun showDeniedForCamera() {
+    }
+
+    @OnNeverAskAgain(Manifest.permission.CAMERA)
+    fun showNeverAskForCamera() {
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        onRequestPermissionsResult(requestCode, grantResults)
+    }
+}

--- a/test/src/test/java/permissions/dispatcher/test/ConductorControllerWithAllAnnotationsKtPermissionsDispatcherTest.kt
+++ b/test/src/test/java/permissions/dispatcher/test/ConductorControllerWithAllAnnotationsKtPermissionsDispatcherTest.kt
@@ -1,0 +1,171 @@
+package permissions.dispatcher.test
+
+import android.app.Activity
+import android.content.pm.PackageManager
+import androidx.core.app.ActivityCompat
+import androidx.core.content.PermissionChecker
+import com.bluelinelabs.conductor.Controller
+import org.junit.After
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Matchers.any
+import org.mockito.Mockito
+import org.powermock.api.mockito.PowerMockito
+import org.powermock.core.classloader.annotations.PrepareForTest
+import org.powermock.modules.junit4.PowerMockRunner
+import permissions.dispatcher.PermissionRequest
+
+@Suppress("IllegalIdentifier")
+@RunWith(PowerMockRunner::class)
+@PrepareForTest(ActivityCompat::class, Controller::class, PermissionChecker::class, ConductorWithAllAnnotationsKt::class)
+class ConductorWithAllAnnotationsKtPermissionsDispatcherTest {
+
+    private lateinit var controller: ConductorWithAllAnnotationsKt
+
+    companion object {
+        private var requestCode = 0
+        private lateinit var requestPermissions: Array<String>
+
+        @BeforeClass
+        @JvmStatic
+        fun setUpForClass() {
+            // TODO Reflection on Kotlin top-level properties?
+            requestCode = 18
+            requestPermissions = arrayOf("android.permission.CAMERA")
+        }
+    }
+
+    @Before
+    fun setUp() {
+        controller = PowerMockito.mock(ConductorWithAllAnnotationsKt::class.java)
+
+        PowerMockito.mockStatic(PermissionChecker::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        clearCustomManufacture()
+        clearCustomSdkInt()
+    }
+
+    @Test
+    fun `already granted call the method`() {
+        mockCheckSelfPermission(true)
+
+        controller.showCameraWithPermissionCheck()
+
+        Mockito.verify(controller, Mockito.times(1)).showCamera()
+    }
+
+    @Test
+    fun `not granted does not call the method`() {
+        mockCheckSelfPermission(false)
+        mockGetActivity(controller, Mockito.mock(Activity::class.java))
+        mockShouldShowRequestPermissionRationaleConductorController(controller, true)
+
+        controller.showCameraWithPermissionCheck()
+
+        Mockito.verify(controller, Mockito.times(0)).showCamera()
+    }
+
+    @Test
+    fun `not granted permission and show rationale is true then call the rationale method`() {
+        mockCheckSelfPermission(false)
+        mockGetActivity(controller, Mockito.mock(Activity::class.java))
+        mockShouldShowRequestPermissionRationaleConductorController(controller, true)
+
+        controller.showCameraWithPermissionCheck()
+
+        Mockito.verify(controller, Mockito.times(1)).showRationaleForCamera(any(PermissionRequest::class.java))
+    }
+
+    @Test
+    fun `not granted permission and show rationale is false then does not call the rationale method`() {
+        mockCheckSelfPermission(false)
+        mockGetActivity(controller, Mockito.mock(Activity::class.java))
+        mockShouldShowRequestPermissionRationaleConductorController(controller, false)
+
+        controller.showCameraWithPermissionCheck()
+
+        Mockito.verify(controller, Mockito.times(0)).showRationaleForCamera(any(PermissionRequest::class.java))
+    }
+
+    @Test
+    fun `the method is called if verifyPermission is true`() {
+        mockGetActivity(controller, Mockito.mock(Activity::class.java))
+        controller.onRequestPermissionsResult(requestCode, intArrayOf(PackageManager.PERMISSION_GRANTED))
+
+        Mockito.verify(controller, Mockito.times(1)).showCamera()
+    }
+
+    @Test
+    fun `the method is not called if verifyPermission is false`() {
+        mockGetActivity(controller, Mockito.mock(Activity::class.java))
+        controller.onRequestPermissionsResult(requestCode, intArrayOf(PackageManager.PERMISSION_DENIED))
+
+        Mockito.verify(controller, Mockito.times(0)).showCamera()
+    }
+
+    @Test
+    fun `show never ask method is call if verifyPermission is false and shouldShowRequestPermissionRationale is false`() {
+        mockGetActivity(controller, Mockito.mock(Activity::class.java))
+        mockShouldShowRequestPermissionRationaleConductorController(controller, false)
+
+        controller.onRequestPermissionsResult(requestCode, intArrayOf(PackageManager.PERMISSION_DENIED))
+
+        Mockito.verify(controller, Mockito.times(1)).showNeverAskForCamera()
+    }
+
+    @Test
+    fun `show deny method is call if verifyPermission is false and shouldShowRequestPermissionRationale is true`() {
+        mockGetActivity(controller, Mockito.mock(Activity::class.java))
+        mockShouldShowRequestPermissionRationaleConductorController(controller, true)
+
+        controller.onRequestPermissionsResult(requestCode, intArrayOf(PackageManager.PERMISSION_DENIED))
+
+        Mockito.verify(controller, Mockito.times(1)).showDeniedForCamera()
+    }
+
+    @Test
+    fun `no the method call if request code is not related to the library`() {
+        controller.onRequestPermissionsResult(requestCode + 1000, intArrayOf())
+
+        Mockito.verify(controller, Mockito.times(0)).showCamera()
+    }
+
+    @Test
+    fun `no denied method call if request code is not related to the library`() {
+        controller.onRequestPermissionsResult(requestCode + 1000, intArrayOf())
+
+        Mockito.verify(controller, Mockito.times(0)).showDeniedForCamera()
+    }
+
+    @Test
+    fun `no never ask method call if request code is not related to the library`() {
+        controller.onRequestPermissionsResult(requestCode + 1000, intArrayOf())
+
+        Mockito.verify(controller, Mockito.times(0)).showNeverAskForCamera()
+    }
+
+    @Test
+    fun `blow M follows checkSelfPermissions result false`() {
+        overwriteCustomSdkInt(22)
+        mockCheckSelfPermission(false)
+
+        controller.showCameraWithPermissionCheck()
+
+        Mockito.verify(controller, Mockito.times(0)).showCamera()
+    }
+
+    @Test
+    fun `blow M follows checkSelfPermissions result true`() {
+        overwriteCustomSdkInt(22)
+        mockCheckSelfPermission(true)
+
+        controller.showCameraWithPermissionCheck()
+
+        Mockito.verify(controller, Mockito.times(1)).showCamera()
+    }
+}

--- a/test/src/test/java/permissions/dispatcher/test/ConductorControllerWithAllAnnotationsKtPermissionsDispatcherTest.kt
+++ b/test/src/test/java/permissions/dispatcher/test/ConductorControllerWithAllAnnotationsKtPermissionsDispatcherTest.kt
@@ -31,8 +31,7 @@ class ConductorWithAllAnnotationsKtPermissionsDispatcherTest {
         @BeforeClass
         @JvmStatic
         fun setUpForClass() {
-            // TODO Reflection on Kotlin top-level properties?
-            requestCode = 18
+            requestCode = ConductorWithAllAnnotationsKt::showCameraWithPermissionCheck.packageLevelGetPropertyValueByName("REQUEST_SHOWCAMERA") as Int
             requestPermissions = arrayOf("android.permission.CAMERA")
         }
     }
@@ -46,7 +45,6 @@ class ConductorWithAllAnnotationsKtPermissionsDispatcherTest {
 
     @After
     fun tearDown() {
-        clearCustomManufacture()
         clearCustomSdkInt()
     }
 

--- a/test/src/test/java/permissions/dispatcher/test/ConductorWithAllAnnotationsPermissionsDispatcherTest.kt
+++ b/test/src/test/java/permissions/dispatcher/test/ConductorWithAllAnnotationsPermissionsDispatcherTest.kt
@@ -1,0 +1,171 @@
+package permissions.dispatcher.test
+
+import android.app.Activity
+import android.content.pm.PackageManager
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityCompat
+import androidx.core.content.PermissionChecker
+import com.bluelinelabs.conductor.Controller
+import org.junit.After
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Matchers.any
+import org.mockito.Mockito
+import org.powermock.api.mockito.PowerMockito
+import org.powermock.core.classloader.annotations.PrepareForTest
+import org.powermock.modules.junit4.PowerMockRunner
+import permissions.dispatcher.PermissionRequest
+
+@Suppress("IllegalIdentifier")
+@RunWith(PowerMockRunner::class)
+@PrepareForTest(ActivityCompat::class, Controller::class, PermissionChecker::class, ConductorWithAllAnnotations::class)
+class ConductorWithAllAnnotationsPermissionsDispatcherTest {
+
+    private lateinit var controller: ConductorWithAllAnnotations
+
+    companion object {
+        private var requestCode = 0
+        private lateinit var requestPermissions: Array<String>
+
+        @BeforeClass
+        @JvmStatic
+        fun setUpForClass() {
+            requestCode = getRequestCameraConstant(ConductorWithAllAnnotationsPermissionsDispatcher::class.java)
+            requestPermissions = getPermissionRequestConstant(ConductorWithAllAnnotationsPermissionsDispatcher::class.java)
+        }
+    }
+
+    @Before
+    fun setUp() {
+        controller = PowerMockito.mock(ConductorWithAllAnnotations::class.java)
+
+        PowerMockito.mockStatic(PermissionChecker::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        clearCustomManufacture()
+        clearCustomSdkInt()
+    }
+
+    @Test
+    fun `already granted call the method`() {
+        mockCheckSelfPermission(true)
+
+        ConductorWithAllAnnotationsPermissionsDispatcher.showCameraWithPermissionCheck(controller)
+
+        Mockito.verify(controller, Mockito.times(1)).showCamera()
+    }
+
+    @Test
+    fun `not granted does not call the method`() {
+        mockCheckSelfPermission(false)
+        mockGetActivity(controller, Mockito.mock(AppCompatActivity::class.java))
+        mockShouldShowRequestPermissionRationaleConductorController(controller, true)
+
+        ConductorWithAllAnnotationsPermissionsDispatcher.showCameraWithPermissionCheck(controller)
+
+        Mockito.verify(controller, Mockito.times(0)).showCamera()
+    }
+
+    @Test
+    fun `not granted permission and show rationale is true then call the rationale method`() {
+        mockCheckSelfPermission(false)
+        mockGetActivity(controller, Mockito.mock(Activity::class.java))
+        mockShouldShowRequestPermissionRationaleConductorController(controller, true)
+
+        ConductorWithAllAnnotationsPermissionsDispatcher.showCameraWithPermissionCheck(controller)
+
+        Mockito.verify(controller, Mockito.times(1)).showRationaleForCamera(any(PermissionRequest::class.java))
+    }
+
+    @Test
+    fun `not granted permission and show rationale is false then does not call the rationale method`() {
+        mockCheckSelfPermission(false)
+        mockGetActivity(controller, Mockito.mock(AppCompatActivity::class.java))
+        mockShouldShowRequestPermissionRationaleConductorController(controller, false)
+
+        ConductorWithAllAnnotationsPermissionsDispatcher.showCameraWithPermissionCheck(controller)
+
+        Mockito.verify(controller, Mockito.times(0)).showRationaleForCamera(any(PermissionRequest::class.java))
+    }
+
+    @Test
+    fun `the method is called if verifyPermission is true`() {
+        ConductorWithAllAnnotationsPermissionsDispatcher.onRequestPermissionsResult(controller, requestCode, intArrayOf(PackageManager.PERMISSION_GRANTED))
+
+        Mockito.verify(controller, Mockito.times(1)).showCamera()
+    }
+
+    @Test
+    fun `the method is not called if verifyPermission is false`() {
+        mockGetActivity(controller, Mockito.mock(AppCompatActivity::class.java))
+        mockShouldShowRequestPermissionRationaleConductorController(controller, true)
+        ConductorWithAllAnnotationsPermissionsDispatcher.onRequestPermissionsResult(controller, requestCode, intArrayOf(PackageManager.PERMISSION_DENIED))
+
+        Mockito.verify(controller, Mockito.times(0)).showCamera()
+    }
+
+    @Test
+    fun `show never ask method is call if verifyPermission is false and shouldShowRequestPermissionRationale is false`() {
+        mockGetActivity(controller, Mockito.mock(AppCompatActivity::class.java))
+        mockShouldShowRequestPermissionRationaleConductorController(controller, false)
+
+        ConductorWithAllAnnotationsPermissionsDispatcher.onRequestPermissionsResult(controller, requestCode, intArrayOf(PackageManager.PERMISSION_DENIED))
+
+        Mockito.verify(controller, Mockito.times(1)).showNeverAskForCamera()
+    }
+
+    @Test
+    fun `show deny method is call if verifyPermission is false and shouldShowRequestPermissionRationale is true`() {
+        mockGetActivity(controller, Mockito.mock(AppCompatActivity::class.java))
+        mockShouldShowRequestPermissionRationaleConductorController(controller, true)
+
+        ConductorWithAllAnnotationsPermissionsDispatcher.onRequestPermissionsResult(controller, requestCode, intArrayOf(PackageManager.PERMISSION_DENIED))
+
+        Mockito.verify(controller, Mockito.times(1)).showDeniedForCamera()
+    }
+
+    @Test
+    fun `no the method call if request code is not related to the library`() {
+        ConductorWithAllAnnotationsPermissionsDispatcher.onRequestPermissionsResult(controller, requestCode + 1000, null)
+
+        Mockito.verify(controller, Mockito.times(0)).showCamera()
+    }
+
+    @Test
+    fun `no denied method call if request code is not related to the library`() {
+        ConductorWithAllAnnotationsPermissionsDispatcher.onRequestPermissionsResult(controller, requestCode + 1000, null)
+
+        Mockito.verify(controller, Mockito.times(0)).showDeniedForCamera()
+    }
+
+    @Test
+    fun `no never ask method call if request code is not related to the library`() {
+        ConductorWithAllAnnotationsPermissionsDispatcher.onRequestPermissionsResult(controller, requestCode + 1000, null)
+
+        Mockito.verify(controller, Mockito.times(0)).showNeverAskForCamera()
+    }
+
+    @Test
+    fun `blow M follows checkSelfPermissions result false`() {
+        overwriteCustomSdkInt(22)
+        mockCheckSelfPermission(false)
+
+        ConductorWithAllAnnotationsPermissionsDispatcher.showCameraWithPermissionCheck(controller)
+
+        Mockito.verify(controller, Mockito.times(0)).showCamera()
+    }
+
+    @Test
+    fun `blow M follows checkSelfPermissions result true`() {
+        overwriteCustomSdkInt(22)
+        mockCheckSelfPermission(true)
+
+        ConductorWithAllAnnotationsPermissionsDispatcher.showCameraWithPermissionCheck(controller)
+
+        Mockito.verify(controller, Mockito.times(1)).showCamera()
+    }
+}

--- a/test/src/test/java/permissions/dispatcher/test/ConductorWithAllAnnotationsPermissionsDispatcherTest.kt
+++ b/test/src/test/java/permissions/dispatcher/test/ConductorWithAllAnnotationsPermissionsDispatcherTest.kt
@@ -46,7 +46,6 @@ class ConductorWithAllAnnotationsPermissionsDispatcherTest {
 
     @After
     fun tearDown() {
-        clearCustomManufacture()
         clearCustomSdkInt()
     }
 

--- a/test/src/test/java/permissions/dispatcher/test/Extensions.kt
+++ b/test/src/test/java/permissions/dispatcher/test/Extensions.kt
@@ -10,6 +10,7 @@ import android.provider.Settings
 import androidx.core.app.ActivityCompat
 import androidx.core.content.PermissionChecker
 import androidx.fragment.app.Fragment
+import com.bluelinelabs.conductor.Controller
 import org.mockito.Matchers.any
 import org.mockito.Matchers.anyString
 import org.powermock.api.mockito.PowerMockito
@@ -76,6 +77,14 @@ fun clearCustomSdkInt() {
 
 fun mockUriParse(result: Uri? = null) {
     PowerMockito.`when`(Uri.parse(anyString())).thenReturn(result)
+}
+
+fun mockShouldShowRequestPermissionRationaleConductorController(controller: Controller, result: Boolean) {
+    PowerMockito.`when`(ActivityCompat.shouldShowRequestPermissionRationale(controller.activity!!, anyString())).thenReturn(result)
+}
+
+fun mockGetActivity(controller: Controller, result: Activity) {
+    PowerMockito.`when`(controller.activity).thenReturn(result)
 }
 
 /**


### PR DESCRIPTION
## Issue

resolves https://github.com/permissions-dispatcher/PermissionsDispatcher/issues/496

## Overview

This PR contains [Conductor](https://github.com/bluelinelabs/Conductor) library support.
The diff is actually smaller than I expected. Just added `JavaConductorProcessorUnit` and `KotlinConductorProcessorUnit` as new processors and remaining diff is test code.

What do you think?