### PR TITLE
Fix Conductor tests

### DIFF
--- a/test/src/test/java/permissions/dispatcher/test/ConductorControllerWithAllAnnotationsKtPermissionsDispatcherTest.kt
+++ b/test/src/test/java/permissions/dispatcher/test/ConductorControllerWithAllAnnotationsKtPermissionsDispatcherTest.kt
@@ -40,6 +40,7 @@ class ConductorWithAllAnnotationsKtPermissionsDispatcherTest {
     fun setUp() {
         controller = PowerMockito.mock(ConductorWithAllAnnotationsKt::class.java)
 
+        PowerMockito.mockStatic(ActivityCompat::class.java)
         PowerMockito.mockStatic(PermissionChecker::class.java)
     }
 

--- a/test/src/test/java/permissions/dispatcher/test/ConductorWithAllAnnotationsPermissionsDispatcherTest.kt
+++ b/test/src/test/java/permissions/dispatcher/test/ConductorWithAllAnnotationsPermissionsDispatcherTest.kt
@@ -41,6 +41,7 @@ class ConductorWithAllAnnotationsPermissionsDispatcherTest {
     fun setUp() {
         controller = PowerMockito.mock(ConductorWithAllAnnotations::class.java)
 
+        PowerMockito.mockStatic(ActivityCompat::class.java)
         PowerMockito.mockStatic(PermissionChecker::class.java)
     }
 

--- a/test/src/test/java/permissions/dispatcher/test/Extensions.kt
+++ b/test/src/test/java/permissions/dispatcher/test/Extensions.kt
@@ -13,6 +13,7 @@ import androidx.fragment.app.Fragment
 import com.bluelinelabs.conductor.Controller
 import org.mockito.Matchers.any
 import org.mockito.Matchers.anyString
+import org.mockito.Matchers.same
 import org.powermock.api.mockito.PowerMockito
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
@@ -80,7 +81,7 @@ fun mockUriParse(result: Uri? = null) {
 }
 
 fun mockShouldShowRequestPermissionRationaleConductorController(controller: Controller, result: Boolean) {
-    PowerMockito.`when`(ActivityCompat.shouldShowRequestPermissionRationale(controller.activity!!, anyString())).thenReturn(result)
+    PowerMockito.`when`(ActivityCompat.shouldShowRequestPermissionRationale(same(controller.activity!!), anyString())).thenReturn(result)
 }
 
 fun mockGetActivity(controller: Controller, result: Activity) {


### PR DESCRIPTION
Fixes:
```
org.mockito.exceptions.misusing.InvalidUseOfMatchersException: 
Misplaced argument matcher detected here:

-> at permissions.dispatcher.test.ExtensionsKt.mockShouldShowRequestPermissionRationaleConductorController(Extensions.kt:83)

You cannot use argument matchers outside of verification or stubbing.
```