### PR TITLE
fix(ktx): allow only 1 observer to receive the event

### DIFF
--- a/ktx/src/main/java/permissions/dispatcher/ktx/PermissionRequestViewModel.kt
+++ b/ktx/src/main/java/permissions/dispatcher/ktx/PermissionRequestViewModel.kt
@@ -21,7 +21,6 @@ internal class PermissionRequestViewModel : ViewModel() {
                 PermissionResult.DENIED_AND_DISABLED -> onNeverAskAgain?.invoke()
                 else -> Unit
             }
-            removeObservers(owner)
         })
     }
 

--- a/ktx/src/main/java/permissions/dispatcher/ktx/PermissionRequestViewModel.kt
+++ b/ktx/src/main/java/permissions/dispatcher/ktx/PermissionRequestViewModel.kt
@@ -25,4 +25,6 @@ internal class PermissionRequestViewModel : ViewModel() {
     }
 
     fun removeObservers(owner: LifecycleOwner) = permissionRequestResult.removeObservers(owner)
+
+    fun hasActiveObservers(): Boolean = permissionRequestResult.hasActiveObservers()
 }

--- a/ktx/src/main/java/permissions/dispatcher/ktx/PermissionRequestViewModel.kt
+++ b/ktx/src/main/java/permissions/dispatcher/ktx/PermissionRequestViewModel.kt
@@ -21,10 +21,9 @@ internal class PermissionRequestViewModel : ViewModel() {
                 PermissionResult.DENIED_AND_DISABLED -> onNeverAskAgain?.invoke()
                 else -> Unit
             }
+            removeObservers(owner)
         })
     }
 
     fun removeObservers(owner: LifecycleOwner) = permissionRequestResult.removeObservers(owner)
-
-    fun hasActiveObservers(): Boolean = permissionRequestResult.hasActiveObservers()
 }

--- a/ktx/src/main/java/permissions/dispatcher/ktx/PermissionsRequesterImpl.kt
+++ b/ktx/src/main/java/permissions/dispatcher/ktx/PermissionsRequesterImpl.kt
@@ -10,23 +10,19 @@ internal class PermissionsRequesterImpl(
     private val onShowRationale: ShowRationaleFun?,
     private val onPermissionDenied: Fun?,
     private val requiresPermission: Fun,
-    onNeverAskAgain: Fun?,
+    private val onNeverAskAgain: Fun?,
     private val permissionRequestType: PermissionRequestType
 ) : PermissionsRequester {
-    init {
-        val viewModel = ViewModelProvider(activity).get(PermissionRequestViewModel::class.java)
-        viewModel.observe(
-            activity,
-            requiresPermission,
-            onPermissionDenied,
-            onNeverAskAgain
-        )
-    }
-
     override fun launch() {
         if (permissionRequestType.checkPermissions(activity, permissions)) {
             requiresPermission()
         } else {
+            ViewModelProvider(activity).get(PermissionRequestViewModel::class.java).observe(
+                activity,
+                requiresPermission,
+                onPermissionDenied,
+                onNeverAskAgain
+            )
             val requestFun = {
                 activity.supportFragmentManager
                     .beginTransaction()

--- a/ktx/src/main/java/permissions/dispatcher/ktx/PermissionsRequesterImpl.kt
+++ b/ktx/src/main/java/permissions/dispatcher/ktx/PermissionsRequesterImpl.kt
@@ -15,9 +15,6 @@ internal class PermissionsRequesterImpl(
 ) : PermissionsRequester {
     init {
         val viewModel = ViewModelProvider(activity).get(PermissionRequestViewModel::class.java)
-        if (viewModel.hasActiveObservers()) {
-            viewModel.removeObservers(activity) // allow only 1 observer to receive the event
-        }
         viewModel.observe(
             activity,
             requiresPermission,

--- a/ktx/src/main/java/permissions/dispatcher/ktx/PermissionsRequesterImpl.kt
+++ b/ktx/src/main/java/permissions/dispatcher/ktx/PermissionsRequesterImpl.kt
@@ -15,6 +15,9 @@ internal class PermissionsRequesterImpl(
 ) : PermissionsRequester {
     init {
         val viewModel = ViewModelProvider(activity).get(PermissionRequestViewModel::class.java)
+        if (viewModel.hasActiveObservers()) {
+            viewModel.removeObservers(activity) // allow only 1 observer to receive the event
+        }
         viewModel.observe(
             activity,
             requiresPermission,


### PR DESCRIPTION
Currently, we allow multiple observers to receive the permission change event but it might cause an unexpected issue.

ref: https://github.com/yt-tkhs/permissionsdispatcher-ktx-issue