### PR TITLE
Use commitAllowingStateLoss() instead of commitNowAllowingStateLoss() in PermissionRequestFragment dismiss() to avoid exception when performing multiple transactions at same time.

### DIFF
--- a/ktx/src/main/java/permissions/dispatcher/ktx/PermissionRequestFragment.kt
+++ b/ktx/src/main/java/permissions/dispatcher/ktx/PermissionRequestFragment.kt
@@ -23,7 +23,7 @@ internal sealed class PermissionRequestFragment : Fragment() {
     }
 
     protected fun dismiss() =
-        fragmentManager?.beginTransaction()?.remove(this)?.commitNowAllowingStateLoss()
+        fragmentManager?.beginTransaction()?.remove(this)?.commitAllowingStateLoss()
 
     internal class NormalRequestPermissionFragment : PermissionRequestFragment() {
         override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
Reported issue:
https://github.com/permissions-dispatcher/PermissionsDispatcher/issues/723