### PR TITLE
Change to use Fragment as a LifecycleOwner when PermissionRequester is constructed by Fragment

### DIFF
--- a/ktx/src/main/java/permissions/dispatcher/ktx/FragmentExtensions.kt
+++ b/ktx/src/main/java/permissions/dispatcher/ktx/FragmentExtensions.kt
@@ -25,6 +25,7 @@ fun Fragment.constructPermissionsRequest(
 ): PermissionsRequester = PermissionsRequesterImpl(
     permissions = permissions,
     activity = requireActivity(),
+    lifecycleOwner = this,
     onShowRationale = onShowRationale,
     onPermissionDenied = onPermissionDenied,
     onNeverAskAgain = onNeverAskAgain,
@@ -50,6 +51,7 @@ fun Fragment.constructLocationPermissionRequest(
 ): PermissionsRequester = PermissionsRequesterImpl(
     permissions = permissions.filterByApiLevel(),
     activity = requireActivity(),
+    lifecycleOwner = this,
     onShowRationale = onShowRationale,
     onPermissionDenied = onPermissionDenied,
     onNeverAskAgain = onNeverAskAgain,
@@ -74,6 +76,7 @@ fun Fragment.constructWriteSettingsPermissionRequest(
 ): PermissionsRequester = PermissionsRequesterImpl(
     permissions = arrayOf(Settings.ACTION_MANAGE_WRITE_SETTINGS),
     activity = requireActivity(),
+    lifecycleOwner = this,
     onShowRationale = onShowRationale,
     onPermissionDenied = onPermissionDenied,
     onNeverAskAgain = null,
@@ -98,6 +101,7 @@ fun Fragment.constructSystemAlertWindowPermissionRequest(
 ): PermissionsRequester = PermissionsRequesterImpl(
     permissions = arrayOf(Settings.ACTION_MANAGE_OVERLAY_PERMISSION),
     activity = requireActivity(),
+    lifecycleOwner = this,
     onShowRationale = onShowRationale,
     onPermissionDenied = onPermissionDenied,
     onNeverAskAgain = null,

--- a/ktx/src/main/java/permissions/dispatcher/ktx/PermissionRequestViewModel.kt
+++ b/ktx/src/main/java/permissions/dispatcher/ktx/PermissionRequestViewModel.kt
@@ -27,14 +27,14 @@ internal class PermissionRequestViewModel : ViewModel() {
         onPermissionDenied: WeakReference<Fun>?,
         onNeverAskAgain: WeakReference<Fun>?
     ) {
-        permissionRequestResult.observe(owner, {
+        permissionRequestResult.observe(owner) {
             when (it[key]?.getContentIfNotHandled()) {
                 PermissionResult.GRANTED -> requiresPermission.get()?.invoke()
                 PermissionResult.DENIED -> onPermissionDenied?.get()?.invoke()
                 PermissionResult.DENIED_AND_DISABLED -> onNeverAskAgain?.get()?.invoke()
                 else -> Unit
             }
-        })
+        }
     }
 
     fun removeObservers(owner: LifecycleOwner) = permissionRequestResult.removeObservers(owner)

--- a/ktx/src/main/java/permissions/dispatcher/ktx/PermissionsRequesterImpl.kt
+++ b/ktx/src/main/java/permissions/dispatcher/ktx/PermissionsRequesterImpl.kt
@@ -1,6 +1,7 @@
 package permissions.dispatcher.ktx
 
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelProvider
 import permissions.dispatcher.PermissionUtils.shouldShowRequestPermissionRationale
 import java.lang.ref.WeakReference
@@ -8,7 +9,8 @@ import java.lang.ref.WeakReference
 internal class PermissionsRequesterImpl(
     private val permissions: Array<out String>,
     private val activity: FragmentActivity,
-    private val onShowRationale: ShowRationaleFun?,
+    lifecycleOwner: LifecycleOwner = activity,
+    val onShowRationale: ShowRationaleFun?,
     private val onPermissionDenied: Fun?,
     private val requiresPermission: Fun,
     onNeverAskAgain: Fun?,
@@ -24,7 +26,7 @@ internal class PermissionsRequesterImpl(
 
     init {
         viewModel.observe(
-            activity,
+            lifecycleOwner,
             // https://github.com/permissions-dispatcher/PermissionsDispatcher/issues/729
             permissions.sortedArray().contentToString(),
             WeakReference(requiresPermission),


### PR DESCRIPTION
Resolves https://github.com/permissions-dispatcher/PermissionsDispatcher/issues/765

# Overview
- Change to use Fragment as a LifecycleOwner when PermissionRequester is constructed by Fragment
- For Activity it changes nothing

# GIFs for my sample app
[before](https://github.com/omtians9425/PermissionsDispatcherKtxSample/tree/main) | [after](https://github.com/omtians9425/PermissionsDispatcherKtxSample/tree/fix_crash_with_lifecycle)
-- | --
<img src="https://user-images.githubusercontent.com/50520222/155821555-996b273c-a571-4d55-992b-2cacf57b1cfb.gif" width=300 /> | <img src="https://user-images.githubusercontent.com/50520222/155821566-7d65ea79-5136-4cff-8fbb-e59b6e6a4c8c.gif" width=300 />



